### PR TITLE
Bump tiiuae/fog-ros-baseimage from builder-latest to v2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_eigen REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -38,7 +39,7 @@ add_library(gremsy ${SOURCES})
 #  $<INSTALL_INTERFACE:include>
 #  ${CMAKE_SOURCE_DIR}/gSDK/src)
 
-ament_target_dependencies(gremsy PUBLIC rclcpp std_msgs std_srvs sensor_msgs geometry_msgs tf2 tf2_geometry_msgs Eigen3 builtin_interfaces)
+ament_target_dependencies(gremsy PUBLIC rclcpp std_msgs std_srvs sensor_msgs geometry_msgs tf2 tf2_geometry_msgs tf2_eigen Eigen3 builtin_interfaces)
 
 
 # DepthAI GStreamer as separate node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:builder-latest AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
 
 COPY . /main_ws/src/
 
@@ -11,7 +11,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:stable
+FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
 
 ENTRYPOINT exec ros-with-env ros2 run ros2_gremsy gremsy_node --ros-args --remap __ns:=/$DRONE_DEVICE_ID -p com_port:=/dev/ttyUSB0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:dp-4266_humble_upgrade AS builder
+FROM ghcr.io/tiiuae/fog-ros-baseimage-builder:v2.0.0 AS builder
 
 COPY . /main_ws/src/
 
@@ -11,7 +11,7 @@ RUN /packaging/build.sh
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:dp-4266_humble_upgrade
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v2.0.0
 
 ENTRYPOINT exec ros-with-env ros2 run ros2_gremsy gremsy_node --ros-args --remap __ns:=/$DRONE_DEVICE_ID -p com_port:=/dev/ttyUSB0
 

--- a/include/ros2_gremsy/gremsy.hpp
+++ b/include/ros2_gremsy/gremsy.hpp
@@ -6,7 +6,7 @@
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <geometry_msgs/msg/quaternion_stamped.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include "ros2_gremsy/utils.hpp"
 #include <../../gSDK/src/gimbal_interface.h>

--- a/include/ros2_gremsy/utils.hpp
+++ b/include/ros2_gremsy/utils.hpp
@@ -32,7 +32,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <geometry_msgs/msg/quaternion_stamped.hpp>


### PR DESCRIPTION
Update fog-ros-baseimage from dp-4266_humble_upgrade to v2.0.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**This PR is now ready for merge.**
