### PR TITLE
PKCS11 updates

### DIFF
--- a/.github/workflows/tii-gremsy.yaml
+++ b/.github/workflows/tii-gremsy.yaml
@@ -13,6 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Free up space
+        uses: jlumbroso/free-disk-space@main
+        
       - uses: actions/checkout@v4
         with:
           submodules: recursive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.1.0-${TARGETARCH:-amd64} AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/tiiuae/fog-ros-sdk:v3.2.0-${TARGETARCH:-amd64} AS builder
 
 # Must be defined another time after "FROM" keyword.
 ARG TARGETARCH
@@ -15,7 +15,7 @@ RUN /packaging/build_colcon_sdk.sh ${TARGETARCH:-amd64}
 #  ▲               runtime ──┐
 #  └── build                 ▼
 
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.1.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
 
 # ENTRYPOINT exec ros-with-env ros2 run ros2_gremsy gremsy_node --ros-args --remap __ns:=/$DRONE_DEVICE_ID -p com_port:=/dev/ttyUSB0
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
- upgrade base images v3.1.0 to v3.2.0
- remove obsolete PKCS11 related env vars
- upgrade msgs-nats if applicable
